### PR TITLE
feat: Add universal MCP configuration CLI with validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Transform medical data analysis with AI! Ask questions about MIMIC-IV data in pl
 
 ## 🚀 Quick Start
 
+> 💡 **Need more options?** Run `m3 --help` to see all available commands and options.
+
 ### Prerequisites
 
 ```bash
@@ -31,16 +33,20 @@ source .venv/bin/activate  # Windows: .venv\Scripts\activate
    ```
 
 2. **Download demo database**:
-
    ```bash
    m3 init mimic-iv-demo
    ```
 
 3. **Setup Claude Desktop**:
-
    ```bash
-   python mcp_client_configs/setup_claude_desktop.py
+   m3 config claude
    ```
+
+   *Alternative: You can also use the interactive config generator:*
+   ```bash
+   m3 config
+   ```
+   *Then select Claude Desktop when prompted.*
 
 4. **Restart Claude Desktop** and ask:
 
@@ -79,33 +85,51 @@ source .venv/bin/activate  # Windows: .venv\Scripts\activate
 
 4. **Setup Claude Desktop for BigQuery**:
    ```bash
-   python mcp_client_configs/setup_claude_desktop.py --backend bigquery --project-id YOUR_PROJECT_ID
+   m3 config claude --backend bigquery --project-id YOUR_PROJECT_ID
    ```
+
+   *Alternative: Use the interactive config generator:*
+   ```bash
+   m3 config
+   ```
+   *Then select BigQuery backend and enter your project ID when prompted.*
 
 5. **Test BigQuery Access** - Restart Claude Desktop and ask:
    ```
    Use the get_race_distribution function to show me the top 5 races in MIMIC-IV admissions.
    ```
 
-## 🔧 Configuration Options
+## 🔧 Advanced Configuration
 
-### SQLite Backend (Default)
+Need to configure other MCP clients or customize settings? Use these commands:
 
+### Interactive Configuration (Universal)
 ```bash
-python mcp_client_configs/setup_claude_desktop.py --backend sqlite
+m3 config
+```
+Generates configuration for any MCP client with step-by-step guidance.
+
+### Quick Configuration Examples
+```bash
+# Quick universal config with defaults
+m3 config --quick
+
+# Universal config with custom database
+m3 config --quick --backend sqlite --db-path /path/to/database.db
+
+# Save config to file for other MCP clients
+m3 config --output my_config.json
 ```
 
+### Backend Comparison
+
+**SQLite Backend (Default)**
 - ✅ **Free**: No cloud costs
 - ✅ **Fast**: Local queries
 - ✅ **Easy**: No authentication needed
 - ❌ **Limited**: Demo dataset only (~1k records)
 
-### BigQuery Backend
-
-```bash
-python mcp_client_configs/setup_claude_desktop.py --backend bigquery --project-id YOUR_PROJECT_ID
-```
-
+**BigQuery Backend**
 - ✅ **Complete**: Full MIMIC-IV dataset (~500k admissions)
 - ✅ **Scalable**: Google Cloud infrastructure
 - ✅ **Current**: Latest MIMIC-IV version (3.1)
@@ -113,7 +137,7 @@ python mcp_client_configs/setup_claude_desktop.py --backend bigquery --project-i
 
 ## 🛠️ Available MCP Tools
 
-When you ask Claude questions, it uses these tools automatically:
+When your MCP client processes questions, it uses these tools automatically:
 
 - **execute_mimic_query**: Run custom SQL queries (SELECT only)
 - **get_patient_demographics**: Patient info from ICU stays
@@ -123,7 +147,7 @@ When you ask Claude questions, it uses these tools automatically:
 
 ## 🧪 Example Queries
 
-Try asking Claude these questions:
+Try asking your MCP client these questions:
 
 **Demographics & Statistics:**
 
@@ -144,21 +168,31 @@ Try asking Claude these questions:
 
 ## 🔍 Troubleshooting
 
+### Common Issues
+
+**SQLite "Database not found" errors:**
+```bash
+# Re-download demo database
+m3 init mimic-iv-demo
+```
+
+**Claude Desktop MCP server not starting:**
+1. Check Claude Desktop logs (Help → View Logs)
+2. Verify configuration: `cat ~/Library/Application\ Support/Claude/claude_desktop_config.json`
+3. Restart Claude Desktop completely
+
 ### BigQuery Issues
 
 **"Access Denied" errors:**
-
 - Ensure you have MIMIC-IV access on PhysioNet
 - Verify your Google Cloud project has BigQuery API enabled
 - Check that you're authenticated: `gcloud auth list`
 
 **"Dataset not found" errors:**
-
 - Confirm your project ID is correct
 - Ensure you have access to `physionet-data` project
 
 **Authentication issues:**
-
 ```bash
 # Re-authenticate
 gcloud auth application-default login
@@ -166,23 +200,6 @@ gcloud auth application-default login
 # Check current authentication
 gcloud auth list
 ```
-
-### SQLite Issues
-
-**"Database not found" errors:**
-
-```bash
-# Re-download demo database
-m3 init mimic-iv-demo
-```
-
-### Claude Desktop Issues
-
-**MCP server not starting:**
-
-1. Check Claude Desktop logs (Help → View Logs)
-2. Verify configuration: `cat ~/Library/Application\ Support/Claude/claude_desktop_config.json`
-3. Restart Claude Desktop completely
 
 ## 👩‍💻 For Developers
 

--- a/mcp_client_configs/dynamic_mcp_config.py
+++ b/mcp_client_configs/dynamic_mcp_config.py
@@ -294,6 +294,21 @@ Examples:
 
     args = parser.parse_args()
 
+    # Validate backend-specific arguments
+    if args.backend == "sqlite" and args.project_id:
+        print(
+            "❌ Error: --project-id can only be used with --backend bigquery",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if args.backend == "bigquery" and args.db_path:
+        print(
+            "❌ Error: --db-path can only be used with --backend sqlite",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     generator = MCPConfigGenerator()
 
     try:

--- a/mcp_client_configs/setup_claude_desktop.py
+++ b/mcp_client_configs/setup_claude_desktop.py
@@ -159,6 +159,15 @@ def main():
 
     args = parser.parse_args()
 
+    # Validate backend-specific arguments
+    if args.backend == "sqlite" and args.project_id:
+        print("❌ Error: --project-id can only be used with --backend bigquery")
+        exit(1)
+
+    if args.backend == "bigquery" and args.db_path:
+        print("❌ Error: --db-path can only be used with --backend sqlite")
+        exit(1)
+
     print("🚀 Setting up M3 MCP Server with Claude Desktop...")
     print(f"📊 Backend: {args.backend}")
 

--- a/tests/test_config_scripts.py
+++ b/tests/test_config_scripts.py
@@ -1,0 +1,119 @@
+"""Tests for MCP configuration scripts."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add the mcp_client_configs directory to the path for testing
+sys.path.insert(0, str(Path(__file__).parent.parent / "mcp_client_configs"))
+
+from dynamic_mcp_config import MCPConfigGenerator
+
+
+class TestMCPConfigGenerator:
+    """Test the MCPConfigGenerator class."""
+
+    def test_generate_config_sqlite_default(self):
+        """Test generating SQLite config with defaults."""
+        generator = MCPConfigGenerator()
+
+        with (
+            patch.object(generator, "_validate_python_path", return_value=True),
+            patch.object(generator, "_validate_directory", return_value=True),
+        ):
+            config = generator.generate_config()
+
+            assert config["mcpServers"]["m3"]["env"]["M3_BACKEND"] == "sqlite"
+            assert "M3_PROJECT_ID" not in config["mcpServers"]["m3"]["env"]
+            assert config["mcpServers"]["m3"]["args"] == ["-m", "m3.mcp_server"]
+
+    def test_generate_config_bigquery_with_project(self):
+        """Test generating BigQuery config with project ID."""
+        generator = MCPConfigGenerator()
+
+        with (
+            patch.object(generator, "_validate_python_path", return_value=True),
+            patch.object(generator, "_validate_directory", return_value=True),
+        ):
+            config = generator.generate_config(
+                backend="bigquery", project_id="test-project"
+            )
+
+            assert config["mcpServers"]["m3"]["env"]["M3_BACKEND"] == "bigquery"
+            assert config["mcpServers"]["m3"]["env"]["M3_PROJECT_ID"] == "test-project"
+            assert (
+                config["mcpServers"]["m3"]["env"]["GOOGLE_CLOUD_PROJECT"]
+                == "test-project"
+            )
+
+    def test_generate_config_sqlite_with_db_path(self):
+        """Test generating SQLite config with custom database path."""
+        generator = MCPConfigGenerator()
+
+        with (
+            patch.object(generator, "_validate_python_path", return_value=True),
+            patch.object(generator, "_validate_directory", return_value=True),
+        ):
+            config = generator.generate_config(
+                backend="sqlite", db_path="/custom/path/database.db"
+            )
+
+            assert config["mcpServers"]["m3"]["env"]["M3_BACKEND"] == "sqlite"
+            assert (
+                config["mcpServers"]["m3"]["env"]["M3_DB_PATH"]
+                == "/custom/path/database.db"
+            )
+
+    def test_generate_config_custom_server_name(self):
+        """Test generating config with custom server name."""
+        generator = MCPConfigGenerator()
+
+        with (
+            patch.object(generator, "_validate_python_path", return_value=True),
+            patch.object(generator, "_validate_directory", return_value=True),
+        ):
+            config = generator.generate_config(server_name="custom-m3")
+
+            assert "custom-m3" in config["mcpServers"]
+            assert "m3" not in config["mcpServers"]
+
+    def test_generate_config_additional_env_vars(self):
+        """Test generating config with additional environment variables."""
+        generator = MCPConfigGenerator()
+
+        with (
+            patch.object(generator, "_validate_python_path", return_value=True),
+            patch.object(generator, "_validate_directory", return_value=True),
+        ):
+            config = generator.generate_config(
+                additional_env={"DEBUG": "true", "LOG_LEVEL": "info"}
+            )
+
+            env = config["mcpServers"]["m3"]["env"]
+            assert env["DEBUG"] == "true"
+            assert env["LOG_LEVEL"] == "info"
+            assert env["M3_BACKEND"] == "sqlite"  # Default should still be there
+
+    def test_validation_invalid_python_path(self):
+        """Test that invalid Python path raises error."""
+        generator = MCPConfigGenerator()
+
+        with (
+            patch.object(generator, "_validate_python_path", return_value=False),
+            patch.object(generator, "_validate_directory", return_value=True),
+        ):
+            with pytest.raises(ValueError, match="Invalid Python path"):
+                generator.generate_config(python_path="/invalid/python")
+
+    def test_validation_invalid_directory(self):
+        """Test that invalid working directory raises error."""
+        generator = MCPConfigGenerator()
+
+        with (
+            patch.object(generator, "_validate_python_path", return_value=True),
+            patch.object(generator, "_validate_directory", return_value=False),
+        ):
+            with pytest.raises(ValueError, match="Invalid working directory"):
+                generator.generate_config(working_directory="/invalid/dir")


### PR DESCRIPTION
- Add `m3 config` and `m3 config claude` commands
- Support interactive and quick configuration modes
- Add backend validation and comprehensive tests
- Replace single-purpose setup with flexible universal system