### PR TITLE
fix: require project_id for BigQuery and remove duplicate setup message

### DIFF
--- a/mcp_client_configs/dynamic_mcp_config.py
+++ b/mcp_client_configs/dynamic_mcp_config.py
@@ -179,16 +179,16 @@ class MCPConfigGenerator:
 
         elif backend == "bigquery":
             print("\n☁️  BigQuery Configuration:")
-            project_id = (
-                input(
-                    "Google Cloud project ID (optional, press Enter to use default): "
+            project_id = None
+            while not project_id:
+                project_id = input(
+                    "Google Cloud project ID (required for BigQuery): "
                 ).strip()
-                or None
-            )
-            if project_id:
-                print(f"✅ Will use project: {project_id}")
-            else:
-                print("✅ Will use default project (physionet-data)")
+                if not project_id:
+                    print(
+                        "❌ Project ID is required when using BigQuery backend. Please enter your GCP project ID."
+                    )
+            print(f"✅ Will use project: {project_id}")
 
         # OAuth2 Configuration
         oauth2_enabled = False
@@ -365,6 +365,14 @@ Examples:
     if args.backend == "bigquery" and args.db_path:
         print(
             "❌ Error: --db-path can only be used with --backend sqlite",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Require project_id for BigQuery backend
+    if args.backend == "bigquery" and not args.project_id:
+        print(
+            "❌ Error: --project-id is required when using --backend bigquery",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/mcp_client_configs/setup_claude_desktop.py
+++ b/mcp_client_configs/setup_claude_desktop.py
@@ -235,6 +235,11 @@ def main():
         print("❌ Error: --db-path can only be used with --backend sqlite")
         exit(1)
 
+    # Require project_id for BigQuery backend
+    if args.backend == "bigquery" and not args.project_id:
+        print("❌ Error: --project-id is required when using --backend bigquery")
+        exit(1)
+
     print("🚀 Setting up M3 MCP Server with Claude Desktop...")
     print(f"📊 Backend: {args.backend}")
 

--- a/src/m3/cli.py
+++ b/src/m3/cli.py
@@ -273,7 +273,7 @@ def config_cmd(
         str | None,
         typer.Option(
             "--project-id",
-            help="Google Cloud project ID (for bigquery backend)",
+            help="Google Cloud project ID (required for bigquery backend)",
         ),
     ] = None,
     python_path: Annotated[
@@ -347,6 +347,15 @@ def config_cmd(
         )
         raise typer.Exit(code=1)
 
+    # Require project_id for BigQuery backend
+    if backend == "bigquery" and not project_id:
+        typer.secho(
+            "❌ Error: --project-id is required when using --backend bigquery",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
     if client == "claude":
         # Run the Claude Desktop setup script
         script_path = project_root / "mcp_client_configs" / "setup_claude_desktop.py"
@@ -369,8 +378,6 @@ def config_cmd(
             cmd.extend(["--db-path", db_path])
         elif backend == "bigquery" and project_id:
             cmd.extend(["--project-id", project_id])
-
-        typer.echo("🚀 Setting up M3 MCP Server with Claude Desktop...")
 
         try:
             result = subprocess.run(cmd, check=True, capture_output=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,14 @@ def test_config_validation_bigquery_with_db_path():
     assert "db-path can only be used with --backend sqlite" in result.output
 
 
+def test_config_validation_bigquery_requires_project_id():
+    """Test that bigquery backend requires project-id parameter."""
+    result = runner.invoke(app, ["config", "claude", "--backend", "bigquery"])
+    assert result.exit_code == 1
+    # Check output - error messages from typer usually go to stdout
+    assert "project-id is required when using --backend bigquery" in result.output
+
+
 @patch("subprocess.run")
 def test_config_claude_success(mock_subprocess):
     """Test successful Claude Desktop configuration."""
@@ -110,7 +118,7 @@ def test_config_claude_success(mock_subprocess):
 
     result = runner.invoke(app, ["config", "claude"])
     assert result.exit_code == 0
-    assert "Setting up M3 MCP Server with Claude Desktop" in result.stdout
+    assert "Claude Desktop configuration completed" in result.stdout
 
     # Verify subprocess was called with correct script
     mock_subprocess.assert_called_once()


### PR DESCRIPTION
Duplicate: ![image](https://github.com/user-attachments/assets/868f4688-1088-4fa1-92a8-3d853bdb344b)

• Remove duplicate 'Setting up M3 MCP Server' message

• Require --project-id for --backend bigquery across all config paths

![image](https://github.com/user-attachments/assets/324edaf4-42e1-4f77-b64a-9bcbdc4ce72b)

• Add validation to CLI, setup script, and dynamic config

• Update interactive mode to require project_id input

• Add test for BigQuery validation and fix affected test