### PR TITLE
Highly Typed-Based Library, M3 x Beartype

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "cryptography>=41.0.0", # Cryptographic operations for JWT
     "python-jose[cryptography]>=3.3.0", # Additional JWT support with crypto
     "httpx>=0.24.0", # Modern HTTP client for OAuth2 token validation
+    "beartype>=0.21.0",
 ]
 
 [project.dependency-groups]

--- a/src/m3/auth.py
+++ b/src/m3/auth.py
@@ -12,6 +12,7 @@ from urllib.parse import urljoin
 
 import httpx
 import jwt
+from beartype import beartype
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
@@ -30,6 +31,7 @@ class TokenValidationError(Exception):
     pass
 
 
+@beartype
 class OAuth2Config:
     """OAuth2 configuration management."""
 
@@ -104,6 +106,7 @@ class OAuth2Config:
         logger.info(f"OAuth2 authentication enabled with issuer: {self.issuer_url}")
 
 
+@beartype
 class OAuth2Validator:
     """OAuth2 token validator."""
 
@@ -351,6 +354,7 @@ def is_oauth2_enabled() -> bool:
     return _oauth2_config is not None and _oauth2_config.enabled
 
 
+@beartype
 def generate_test_token(
     issuer: str = "https://test-issuer.example.com",
     audience: str = "m3-api",

--- a/src/m3/cli.py
+++ b/src/m3/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from beartype import beartype
 
 from m3 import __version__
 from m3.config import (
@@ -67,6 +68,7 @@ def main_callback(
 
 
 @app.command("init")
+@beartype
 def dataset_init_cmd(
     dataset_name: Annotated[
         str,

--- a/src/m3/config.py
+++ b/src/m3/config.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
 
+from beartype import beartype
+
 APP_NAME = "m3"
 
 # Setup basic logging
@@ -55,11 +57,13 @@ SUPPORTED_DATASETS = {
 # --------------------------------------------------
 # Helper functions
 # --------------------------------------------------
+@beartype
 def get_dataset_config(dataset_name: str) -> dict | None:
     """Retrieve the configuration for a given dataset (case-insensitive)."""
     return SUPPORTED_DATASETS.get(dataset_name.lower())
 
 
+@beartype
 def get_default_database_path(dataset_name: str) -> Path | None:
     """
     Return the default SQLite DB path for a given dataset,
@@ -74,6 +78,7 @@ def get_default_database_path(dataset_name: str) -> Path | None:
     return None
 
 
+@beartype
 def get_dataset_raw_files_path(dataset_name: str) -> Path | None:
     """
     Return the raw-file storage path for a dataset,

--- a/src/m3/data_io.py
+++ b/src/m3/data_io.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin, urlparse
 import polars as pl
 import requests
 import typer
+from beartype import beartype
 from bs4 import BeautifulSoup
 
 from m3.config import get_dataset_config, get_dataset_raw_files_path, logger
@@ -14,6 +15,7 @@ COMMON_USER_AGENT = (
 )
 
 
+@beartype
 def _download_single_file(
     url: str, target_filepath: Path, session: requests.Session
 ) -> bool:
@@ -60,6 +62,7 @@ def _download_single_file(
     return False
 
 
+@beartype
 def _scrape_urls_from_html_page(
     page_url: str, session: requests.Session, file_suffix: str = ".csv.gz"
 ) -> list[str]:
@@ -85,6 +88,7 @@ def _scrape_urls_from_html_page(
     return found_urls
 
 
+@beartype
 def _download_dataset_files(
     dataset_name: str, dataset_config: dict, raw_files_root_dir: Path
 ) -> bool:
@@ -176,6 +180,7 @@ def _download_dataset_files(
     return downloaded_count == len(unique_files_to_process)
 
 
+@beartype
 def _load_csv_with_robust_parsing(csv_file_path: Path, table_name: str) -> pl.DataFrame:
     """
     Load a CSV file with proper type inference by scanning the entire file.
@@ -205,6 +210,7 @@ def _load_csv_with_robust_parsing(csv_file_path: Path, table_name: str) -> pl.Da
     return df
 
 
+@beartype
 def _etl_csv_collection_to_sqlite(csv_source_dir: Path, db_target_path: Path) -> bool:
     """Loads all .csv.gz files from a directory structure into an SQLite database."""
     db_target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -299,6 +305,7 @@ def _etl_csv_collection_to_sqlite(csv_source_dir: Path, db_target_path: Path) ->
         return False
 
 
+@beartype
 def initialize_dataset(dataset_name: str, db_target_path: Path) -> bool:
     """Initializes a dataset: downloads files and loads them into a database."""
     dataset_config = get_dataset_config(dataset_name)

--- a/src/m3/mcp_client_configs/dynamic_mcp_config.py
+++ b/src/m3/mcp_client_configs/dynamic_mcp_config.py
@@ -10,6 +10,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from beartype import beartype
+
 # Error messages
 _DATABASE_PATH_ERROR_MSG = (
     "Could not determine default database path for mimic-iv-demo.\n"
@@ -17,6 +19,7 @@ _DATABASE_PATH_ERROR_MSG = (
 )
 
 
+@beartype
 class MCPConfigGenerator:
     """Generator for MCP server configurations."""
 
@@ -263,6 +266,7 @@ class MCPConfigGenerator:
         )
 
 
+@beartype
 def print_config_info(config: dict[str, Any]):
     """Print configuration information."""
     # Get the first (and likely only) server configuration

--- a/src/m3/mcp_client_configs/setup_claude_desktop.py
+++ b/src/m3/mcp_client_configs/setup_claude_desktop.py
@@ -8,6 +8,8 @@ import os
 import shutil
 from pathlib import Path
 
+from beartype import beartype
+
 
 def get_claude_config_path():
     """Get the Claude Desktop configuration file path."""
@@ -56,12 +58,13 @@ def get_python_path():
     return shutil.which("python") or shutil.which("python3") or "python"
 
 
+@beartype
 def create_mcp_config(
-    backend="sqlite",
-    db_path=None,
-    project_id=None,
-    oauth2_enabled=False,
-    oauth2_config=None,
+    backend: str = "sqlite",
+    db_path: str | None = None,
+    project_id: str | None = None,
+    oauth2_enabled: bool = False,
+    oauth2_config: str | None = None,
 ):
     """Create MCP server configuration."""
     current_dir = get_current_directory()
@@ -112,12 +115,13 @@ def create_mcp_config(
     return config
 
 
+@beartype
 def setup_claude_desktop(
-    backend="sqlite",
-    db_path=None,
-    project_id=None,
-    oauth2_enabled=False,
-    oauth2_config=None,
+    backend: str = "sqlite",
+    db_path: str | None = None,
+    project_id: str | None = None,
+    oauth2_enabled: bool = False,
+    oauth2_config: str | None = None,
 ):
     """Setup Claude Desktop with M3 MCP server."""
     try:

--- a/src/m3/mcp_server.py
+++ b/src/m3/mcp_server.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pandas as pd
 import sqlparse
+from beartype import beartype
 from fastmcp import FastMCP
 
 from m3.auth import init_oauth2, require_oauth2
@@ -24,11 +25,13 @@ _bq_client = None
 _project_id = None
 
 
+@beartype
 def _validate_limit(limit: int) -> bool:
     """Validate limit parameter to prevent resource exhaustion."""
     return isinstance(limit, int) and 0 < limit <= 1000
 
 
+@beartype
 def _is_safe_query(sql_query: str, internal_tool: bool = False) -> tuple[bool, str]:
     """Secure SQL validation - blocks injection attacks, allows legitimate queries."""
     try:
@@ -189,6 +192,7 @@ def _get_backend_info() -> str:
 # from calling other MCP tools, which violates the MCP protocol.
 
 
+@beartype
 def _execute_sqlite_query(sql_query: str) -> str:
     """Execute SQLite query - internal function."""
     try:
@@ -214,6 +218,7 @@ def _execute_sqlite_query(sql_query: str) -> str:
         raise e
 
 
+@beartype
 def _execute_bigquery_query(sql_query: str) -> str:
     """Execute BigQuery query - internal function."""
     try:
@@ -240,6 +245,7 @@ def _execute_bigquery_query(sql_query: str) -> str:
         raise e
 
 
+@beartype
 def _execute_query_internal(sql_query: str) -> str:
     """Internal query execution function that handles backend routing."""
     # Security check
@@ -341,6 +347,7 @@ def _execute_query_internal(sql_query: str) -> str:
 
 
 @mcp.tool()
+@beartype
 @require_oauth2
 def get_database_schema() -> str:
     """🔍 Discover what data is available in the MIMIC-IV database.
@@ -375,6 +382,7 @@ def get_database_schema() -> str:
 
 
 @mcp.tool()
+@beartype
 @require_oauth2
 def get_table_info(table_name: str, show_sample: bool = True) -> str:
     """📋 Explore a specific table's structure and see sample data.
@@ -506,6 +514,7 @@ def get_table_info(table_name: str, show_sample: bool = True) -> str:
 
 
 @mcp.tool()
+@beartype
 @require_oauth2
 def execute_mimic_query(sql_query: str) -> str:
     """🚀 Execute SQL queries to analyze MIMIC-IV data.
@@ -532,6 +541,7 @@ def execute_mimic_query(sql_query: str) -> str:
 
 
 @mcp.tool()
+@beartype
 @require_oauth2
 def get_icu_stays(patient_id: int | None = None, limit: int = 10) -> str:
     """🏥 Get ICU stay information and length of stay data.
@@ -579,6 +589,7 @@ This ensures compatibility across different MIMIC-IV setups."""
 
 
 @mcp.tool()
+@beartype
 @require_oauth2
 def get_lab_results(
     patient_id: int | None = None, lab_item: str | None = None, limit: int = 20
@@ -638,6 +649,7 @@ This ensures compatibility across different MIMIC-IV setups."""
 
 
 @mcp.tool()
+@beartype
 @require_oauth2
 def get_race_distribution(limit: int = 10) -> str:
     """📊 Get race distribution from hospital admissions.

--- a/tests/test_type_checks.py
+++ b/tests/test_type_checks.py
@@ -1,0 +1,206 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import requests
+from beartype.roar import BeartypeCallHintParamViolation
+
+from m3.auth import OAuth2Validator, generate_test_token
+from m3.cli import dataset_init_cmd
+from m3.config import (
+    get_dataset_config,
+    get_dataset_raw_files_path,
+    get_default_database_path,
+)
+from m3.data_io import (
+    _download_single_file,
+    _etl_csv_collection_to_sqlite,
+    _load_csv_with_robust_parsing,
+    _scrape_urls_from_html_page,
+    initialize_dataset,
+)
+from m3.mcp_client_configs.dynamic_mcp_config import MCPConfigGenerator
+from m3.mcp_client_configs.setup_claude_desktop import create_mcp_config
+
+with patch("pathlib.Path.exists", return_value=True):
+    with patch(
+        "m3.mcp_server.get_default_database_path", return_value=Path("/fake/test.db")
+    ):
+        from m3.mcp_server import (
+            _is_safe_query,
+            _validate_limit,
+        )
+
+
+class TestTypeChecks:
+    """
+    Test class for verifying type checks enforced by beartype across M3.
+    """
+
+    @pytest.mark.parametrize("invalid_input", [123, ["list"], {"dict": 1}, None])
+    def test_config_get_dataset_config(self, invalid_input):
+        """Test get_dataset_config with invalid dataset_name types."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            get_dataset_config(invalid_input)
+
+    @pytest.mark.parametrize("invalid_input", [123, ["list"], {"dict": 1}, None])
+    def test_config_get_default_database_path(self, invalid_input):
+        """Test get_default_database_path with invalid dataset_name types."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            get_default_database_path(invalid_input)
+
+    @pytest.mark.parametrize("invalid_input", [123, ["list"], {"dict": 1}, None])
+    def test_config_get_dataset_raw_files_path(self, invalid_input):
+        """Test get_dataset_raw_files_path with invalid dataset_name types."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            get_dataset_raw_files_path(invalid_input)
+
+    def test_data_io_download_single_file_invalid_url(self):
+        """Test _download_single_file with invalid url type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _download_single_file(123, Path("/tmp/file"), requests.Session())
+
+    def test_data_io_download_single_file_invalid_target_filepath(self):
+        """Test _download_single_file with invalid target_filepath type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _download_single_file("http://example.com", "/tmp/file", requests.Session())
+
+    def test_data_io_download_single_file_invalid_session(self):
+        """Test _download_single_file with invalid session type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _download_single_file("http://example.com", Path("/tmp/file"), 123)
+
+    def test_data_io_scrape_urls_from_html_page_invalid_page_url(self):
+        """Test _scrape_urls_from_html_page with invalid page_url type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _scrape_urls_from_html_page(123, requests.Session())
+
+    def test_data_io_scrape_urls_from_html_page_invalid_session(self):
+        """Test _scrape_urls_from_html_page with invalid session type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _scrape_urls_from_html_page("http://example.com", 123)
+
+    def test_data_io_scrape_urls_from_html_page_invalid_file_suffix(self):
+        """Test _scrape_urls_from_html_page with invalid file_suffix type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _scrape_urls_from_html_page(
+                "http://example.com", requests.Session(), file_suffix=123
+            )
+
+    def test_data_io_load_csv_with_robust_parsing_invalid_csv_file_path(self):
+        """Test _load_csv_with_robust_parsing with invalid csv_file_path type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _load_csv_with_robust_parsing("/invalid/path", "table_name")
+
+    def test_data_io_load_csv_with_robust_parsing_invalid_table_name(self):
+        """Test _load_csv_with_robust_parsing with invalid table_name type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _load_csv_with_robust_parsing(Path("/tmp/file.csv"), 123)
+
+    def test_data_io_etl_csv_collection_to_sqlite_invalid_csv_source_dir(self):
+        """Test _etl_csv_collection_to_sqlite with invalid csv_source_dir type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _etl_csv_collection_to_sqlite("/invalid/path", Path("/tmp/db.db"))
+
+    def test_data_io_etl_csv_collection_to_sqlite_invalid_db_target_path(self):
+        """Test _etl_csv_collection_to_sqlite with invalid db_target_path type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _etl_csv_collection_to_sqlite(Path("/tmp"), "/invalid/path")
+
+    def test_data_io_initialize_dataset_invalid_dataset_name(self):
+        """Test initialize_dataset with invalid dataset_name type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            initialize_dataset(123, Path("/tmp/db.db"))
+
+    def test_data_io_initialize_dataset_invalid_db_target_path(self):
+        """Test initialize_dataset with invalid db_target_path type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            initialize_dataset("mimic-iv-demo", "/invalid/path")
+
+    @pytest.mark.parametrize(
+        "invalid_limit", ["string", 3.14, None, [1], {"key": "value"}]
+    )
+    def test_mcp_server_validate_limit(self, invalid_limit):
+        """Test _validate_limit with invalid limit types."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _validate_limit(invalid_limit)
+
+    @pytest.mark.parametrize("invalid_sql_query", [123, ["list"], {"dict": 1}, None])
+    def test_mcp_server_is_safe_query_sql_query(self, invalid_sql_query):
+        """Test _is_safe_query with invalid sql_query types."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _is_safe_query(invalid_sql_query)
+
+    @pytest.mark.parametrize(
+        "invalid_internal_tool", ["string", 123, [1], {"key": "value"}]
+    )
+    def test_mcp_server_is_safe_query_internal_tool(self, invalid_internal_tool):
+        """Test _is_safe_query with invalid internal_tool types."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _is_safe_query("SELECT * FROM table", internal_tool=invalid_internal_tool)
+
+    def test_auth_oauth2_validator_wrong_config(self):
+        """Test OAuth2Validator.__init__ with invalid config type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            _ = OAuth2Validator(123)
+
+    def test_auth_generate_test_token_invalid_issuer(self):
+        """Test generate_test_token with invalid issuer type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            generate_test_token(issuer=123)
+
+    def test_auth_generate_test_token_invalid_audience(self):
+        """Test generate_test_token with invalid audience type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            generate_test_token(audience=123)
+
+    def test_auth_generate_test_token_invalid_subject(self):
+        """Test generate_test_token with invalid subject type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            generate_test_token(subject=123)
+
+    def test_auth_generate_test_token_invalid_scopes(self):
+        """Test generate_test_token with invalid scopes type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            generate_test_token(scopes="invalid")
+
+    def test_auth_generate_test_token_invalid_expires_in(self):
+        """Test generate_test_token with invalid expires_in type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            generate_test_token(expires_in="string")
+
+    def test_cli_dataset_init_cmd_invalid_dataset_name(self):
+        """Test dataset_init_cmd with invalid dataset_name type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            dataset_init_cmd(123)
+
+    def test_cli_dataset_init_cmd_invalid_db_path_str(self):
+        """Test dataset_init_cmd with invalid db_path_str type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            dataset_init_cmd(db_path_str=123)
+
+    def test_dynamic_mcp_config_generate_config_invalid_server_name(self):
+        """Test MCPConfigGenerator.generate_config with invalid server_name type."""
+        generator = MCPConfigGenerator()
+        with pytest.raises(BeartypeCallHintParamViolation):
+            generator.generate_config(server_name=123)
+
+    def test_setup_claude_desktop_create_mcp_config_invalid_backend(self):
+        """Test create_mcp_config with invalid backend type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            create_mcp_config(backend=123)
+
+    def test_setup_claude_desktop_create_mcp_config_invalid_db_path(self):
+        """Test create_mcp_config with invalid db_path type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            create_mcp_config(db_path=123)
+
+    def test_setup_claude_desktop_create_mcp_config_invalid_project_id(self):
+        """Test create_mcp_config with invalid project_id type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            create_mcp_config(project_id=123)
+
+    def test_setup_claude_desktop_create_mcp_config_invalid_oauth2_enabled(self):
+        """Test create_mcp_config with invalid oauth2_enabled type."""
+        with pytest.raises(BeartypeCallHintParamViolation):
+            create_mcp_config(oauth2_enabled="string")

--- a/uv.lock
+++ b/uv.lock
@@ -63,6 +63,15 @@ wheels = [
 ]
 
 [[package]]
+name = "beartype"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/f9/21e5a9c731e14f08addd53c71fea2e70794e009de5b98e6a2c3d2f3015d6/beartype-0.21.0.tar.gz", hash = "sha256:f9a5078f5ce87261c2d22851d19b050b64f6a805439e8793aecf01ce660d3244", size = 1437066, upload-time = "2025-05-22T05:09:27.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/31/87045d1c66ee10a52486c9d2047bc69f00f2689f69401bb1e998afb4b205/beartype-0.21.0-py3-none-any.whl", hash = "sha256:b6a1bd56c72f31b0a496a36cc55df6e2f475db166ad07fa4acc7e74f4c7f34c0", size = 1191340, upload-time = "2025-05-22T05:09:24.606Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -687,6 +696,7 @@ name = "m3-mcp"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },
+    { name = "beartype" },
     { name = "beautifulsoup4" },
     { name = "cryptography" },
     { name = "db-dtypes" },
@@ -707,6 +717,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "appdirs", specifier = ">=1.4.0" },
+    { name = "beartype", specifier = ">=0.21.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "db-dtypes", specifier = ">=1.0.0" },


### PR DESCRIPTION
Hi folks!

Hoping what follows helps!

Pushing some typing-verification improvements.   [Beartype](https://github.com/beartype/beartype) is a `O(1)`-based runtime type checker.  w/ the current codebase, the typing benefit is either solely visually beneficial (s.t. helping each other grasp what a particular variable, parameter, or return's function type is, which is brills anyway!) or a bit better might be statically linted, given some of our IDEs.

w/ Beartype (from the great @leycec!), `M3` ensures during runtime that data flows the way it has been requested (/typed) and simply r(aise)oar in case something is not passing the right data type, all that surprisingly fast!

However, I applied `@beartype` to as many locations as I believed would be useful; if this is too much or not enough, I will let the reviewer decide, but gradually adopting `beartype` could only be beneficial.  Note that I only tried with the local minimum demo and not any of the g.bigquery's, so it may be worth a go on your end, please.

_https://beartype.readthedocs.io/en/latest/_


Cheers